### PR TITLE
Fix URL in wt create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This extension will expose an endpoint you can use from your monitoring tool to 
 ```
 npm i -g wt-cli
 wt init
-wt create https://raw.githubusercontent.com/auth0/auth0-ldap-connector-health-monitor/master/index.js \
+wt create https://raw.githubusercontent.com/auth0/auth0-ldap-conector-health-monitor/master/index.js \
     --name auth0-ldap-connector-health-monitor \
     --secret AUTH0_DOMAIN="YOUR_AUTH0_DOMAIN" \
     --secret AUTH0_GLOBAL_CLIENT_ID="YOUR_AUTH0_GLOBAL_CLIENT_ID" \


### PR DESCRIPTION
Unfortunately the Github project name is misspelled but the README isn't. The project name is missing an "n" in "connector":
auth0-ldap-conector-health-monitor
So this PR fixes the README, but we should probably rename the project.
