### PR TITLE
Fix handling of the connections endpoint response

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,11 +57,12 @@ module.exports = (ctx, req, res) => {
           'Authorization': `Bearer ${token}`
         }
       }, (err, resp, body) => {
-        body = JSON.parse(body);
-
         if (err) return end(500, { message: 'Error calling the monitoring endpoint.', details: err.message });
         else if (resp.statusCode === 404) return end(400, { message: 'The connection does not exist.' });
-        else if (body.strategy !== 'ad' && body.strategy !== 'auth0-adldap') {
+        else if (resp.statusCode !== 200) return end(400, { message: 'Failed to obtain connection information.' });
+
+        body = JSON.parse(body);
+        if (body.strategy !== 'ad' && body.strategy !== 'auth0-adldap') {
           return end(400, { message: 'The connection is not an AD/LDAP connection.' });
         }
 


### PR DESCRIPTION
## ✏️ Changes
  
The response of the connections endpoint was being parsed as JSON without checking if we really had JSON (success response); this then lead to the extension throwing an unhandled error whenever the response body was not valid JSON. For example, the connections endpoint responds with a 502 response containing HTML.
 
## 🎯 Testing
  
Performed manual/local testing for the scenarios in scope of the change; in other words, tested that with a success (200) response the body is parsed correctly and that any other status code for the endpoint in question it will return a general error message.
  
## 🚀 Deployment

✅ This can be deployed any time
  
