### PR TITLE
Use API2 for checking connection status

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ wt init
 wt create https://raw.githubusercontent.com/auth0/auth0-ldap-connector-health-monitor/master/index.js \
     --name auth0-ldap-connector-health-monitor \
     --secret AUTH0_DOMAIN="YOUR_AUTH0_DOMAIN" \
-    --secret AUTH0_GLOBAL_CLIENT_ID="YOUR_AUTH0_GLOBAL_CLIENT_ID" \
-    --secret AUTH0_GLOBAL_CLIENT_SECRET="YOUR_AUTH0_GLOBAL_CLIENT_SECRET"
+    --secret AUTH0_CLIENT_ID="YOUR_AUTH0_CLIENT_ID" \
+    --secret AUTH0_CLIENT_SECRET="YOUR_AUTH0_CLIENT_SECRET"
 ```
 
-> You can get your Global Client Id/Secret here: https://auth0.com/docs/api/v1
+The client ID and secret must be for a Machine-to-Machine Application with access to the Management API and a `read:connections` grant. See https://auth0.com/docs/api/management/v2/create-m2m-app for more information.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -63,7 +63,8 @@ module.exports = (ctx, req, res) => {
         qs: {
           name: connectionName,
           page: 0,
-          per_page: 1
+          per_page: 1,
+          fields: "id,strategy"
         },
         json: true
       }, (err, resp, body) => {

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 AD/LDAP Connector Health Monitor",
   "name": "auth0-ldap-conector-health-monitor",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "author": "auth0",
   "description": "This extension will expose an endpoint you can use from your monitoring tool to monitor your AD/LDAP Connectors",
   "type": "application",
@@ -13,11 +13,11 @@
     "AUTH0_DOMAIN": {
       "description": "Auth0 domain"
     },
-    "AUTH0_GLOBAL_CLIENT_ID": {
-      "description": "Auth0 global ClientID"
+    "AUTH0_CLIENT_ID": {
+      "description": "Auth0 Management API ClientID"
     },
-    "AUTH0_GLOBAL_CLIENT_SECRET": {
-      "description": "Auth0 global ClientSecret"
+    "AUTH0_CLIENT_SECRET": {
+      "description": "Auth0 Management API ClientSecret"
     }
   }
 }


### PR DESCRIPTION
## ✏️ Changes
  
Use Management API v2 endpoints instead of v1.

This PR introduces a breaking change: configuration now requires a valid Management API v2 client with `read:connections` scope grant, instead of the global client. 

This also changes the variable names you need to configure for the extension:

`AUTH0_GLOBAL_CLIENT_ID` is now `AUTH0_CLIENT_ID`
`AUTH0_GLOBAL_CLIENT_SECRET` is now `AUTH0_CLIENT_SECRET`

Uses upgrading to this version will need to create a correctly configured Management API v2 client, and update their configuration before upgrading.

 ## 🎯 Testing
     
✅ This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
    
✅ This can be deployed any time
  
## 🎡 Rollout
  
In order to verify that the deployment was successful a current extension installation needs to be updated to the new version. Making requests to:

`GET https://webtask.it.auth0.com/api/run/{YOUR_CONTAINER_NAME}/ldap-connector-health?connection={your connection name}`

Should return the same value as before (200 for open connection, 400 for closed/inexisting connection).
  
## 🔥 Rollback
  
The change can be reverted at any time, since the previous way to check for connection status is still available.