### PR TITLE
Provision client automatically

### DIFF
--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 AD/LDAP Connector Health Monitor",
   "name": "auth0-ldap-conector-health-monitor",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "auth0",
   "description": "This extension will expose an endpoint you can use from your monitoring tool to monitor your AD/LDAP Connectors",
   "type": "application",
@@ -9,15 +9,9 @@
     "auth0",
     "extension"
   ],
-  "secrets": {
-    "AUTH0_DOMAIN": {
-      "description": "Auth0 domain"
-    },
-    "AUTH0_CLIENT_ID": {
-      "description": "Auth0 Management API ClientID"
-    },
-    "AUTH0_CLIENT_SECRET": {
-      "description": "Auth0 Management API ClientSecret"
-    }
+  "auth0": {
+    "createClient": true,
+    "onUninstallPath": "/.extensions/on-uninstall",
+    "scopes": "read:connections"
   }
 }


### PR DESCRIPTION
## ✏️ Changes

Updated the configuration to simplify install experience.
  
AUTH0_DOMAIN is injected automatically, and AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET is injected from an automatically provisioned client when createClient: true. 