### PR TITLE
Remove auth0-adldap connections query

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const PAGE_SIZE = 100;
 const MAX_AGE = 60000;
 
 /**
- * Fetch all 'ad' and 'auth0-adldap' connections.
+ * Fetch all 'ad' connections.
  * @param {string} token access token with read:connections scope
  * @param {number} [page] page number
  * @param {Function} cb callback with connection array
@@ -42,7 +42,7 @@ function getConnections(domain, token, page, cb) {
       'Authorization': `Bearer ${token}`
     },
     qs: {
-      strategy: ['ad', 'auth0-adldap'],
+      strategy: ['ad'],
       page,
       per_page: PAGE_SIZE,
       fields: 'id,name'

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 AD/LDAP Connector Health Monitor",
   "name": "auth0-ldap-conector-health-monitor",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": "auth0",
   "description": "This extension will expose an endpoint you can use from your monitoring tool to monitor your AD/LDAP Connectors",
   "type": "application",


### PR DESCRIPTION
The `auth0-adldap` strategy is no longer supported. Stop querying it for health checks.