### PR TITLE
chore: [IUM-3387] pin dependency versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_ROLE: ${{ secrets.awsIAMS3UploadRole }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+
+      - name: Configure AWS Credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1 on 2025-04-30
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          role-session-name: github-ldap-connector-health-monitor-publish
+          aws-region: us-west-1
+
+      - name: Run Deploy
+        run: sh tools/cdn.sh

--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@
  * calls to the GET /api/v2/connections endpoint so we don't impact the tenant rate limits.
  */
 
-const createError = require('http-errors')
-const request = require('request');
+const createError = require('http-errors@1.3.1');
+const request = require('request@2.88.2');
 const url = require('url');
-const lruMemoizer = require('lru-memoizer');
+const lruMemoizer = require('lru-memoizer@1.10.0');
 
 /** number of connections to retrieve per page */
 const PAGE_SIZE = 100;

--- a/tools/cdn.sh
+++ b/tools/cdn.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+# The 'conector' typo is 'correct' by now, because it's already used in deployments
+EXTENSION_NAME="auth0-ldap-conector-health-monitor"
+JSON_FILE="webtask.json"
+S3_PATH="s3://assets.us.auth0.com/extensions/$EXTENSION_NAME/"
+
+# Extract full version with patch version (eg: 2.1.3)
+FULL_VERSION=$(jq -r '.version' "$JSON_FILE")
+if [ -z "$FULL_VERSION" ] || [ "$FULL_VERSION" = "null" ]; then
+  echo "Error: Could not extract version from $JSON_FILE."
+  exit 1
+fi
+
+echo "Extracted full version: $FULL_VERSION"
+
+# Extract major.minor version without patch version (eg: 2.1)
+# Use shell parameter expansion
+MAJORMINOR_VERSION_ONLY=${FULL_VERSION%.*}
+if [ -z "$MAJORMINOR_VERSION_ONLY" ] || [ "$MAJORMINOR_VERSION_ONLY" = "null" ]; then
+  echo "Error: Could not extract major.minor version from $JSON_FILE."
+  exit 1
+fi
+
+echo "Extracted major.minor version: $MAJORMINOR_VERSION_ONLY"
+
+deploy_bundle() {
+  local version_to_deploy="$1"
+  local expected_filename="$EXTENSION_NAME-$version_to_deploy.js"
+  local expected_path=$S3_PATH$expected_filename
+
+  echo " "
+  echo "--- Deploying v$version_to_deploy to $expected_path ---"
+
+  aws s3 cp index.js "$expected_path"
+  upload_exit_status=$?
+  if [ $upload_exit_status -ne 0 ]; then
+    echo "Error: Failed to upload $expected_filename to $expected_path"
+    exit 1
+  else
+    echo "$expected_filename uploaded successfully to $expected_path."
+  fi
+  echo "--- Finished deployment step for v$version_to_deploy ---"
+  echo " "
+}
+
+error_if_bundle_exists() {
+  local version_to_check="$1"
+  local expected_filename="$EXTENSION_NAME-$version_to_check.js"
+
+  echo "Checking for existing bundle: $version_to_check in $S3_PATH"
+
+  aws_output=$(aws s3 ls "$S3_PATH")
+  aws_ls_exit_status=$?
+
+  # Check if aws s3 ls command itself failed
+  if [ $aws_ls_exit_status -ne 0 ]; then
+    echo "Error: 'aws s3 ls $S3_PATH' failed with exit status $aws_ls_exit_status."
+    exit 1
+  fi
+
+  # Check if the specific file exists
+  BUNDLE_EXISTS=$(echo "$aws_output" | grep $expected_filename)
+  if [ ! -z "$BUNDLE_EXISTS" ]; then
+    echo "Bundle $expected_filename already exists in $S3_PATH. Skipping cdn publish."
+    exit 1
+  fi
+}
+
+# If full version (eg: 2.1.3) exists in CDN already, exit this script and don't upload the major.minor version
+error_if_bundle_exists "$FULL_VERSION"
+
+echo "Bundle $FULL_VERSION not found. Proceeding with upload..."
+deploy_bundle "$FULL_VERSION"
+deploy_bundle "$MAJORMINOR_VERSION_ONLY"
+
+echo "Script finished."

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 AD/LDAP Connector Health Monitor",
   "name": "auth0-ldap-conector-health-monitor",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "auth0",
   "description": "This extension will expose an endpoint you can use from your monitoring tool to monitor your AD/LDAP Connectors",
   "type": "application",

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 AD/LDAP Connector Health Monitor",
   "name": "auth0-ldap-conector-health-monitor",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "author": "auth0",
   "description": "This extension will expose an endpoint you can use from your monitoring tool to monitor your AD/LDAP Connectors",
   "type": "application",


### PR DESCRIPTION
## ✏️ Changes
  
This PR pins some dependency versions in preparation for upgrading to node22. 

It also adds deploy tooling. I test deployed this code to:
- https://cdn.auth0.com/extensions/auth0-ldap-conector-health-monitor/develop/auth0-ldap-conector-health-monitor-2.2.js
- https://cdn.auth0.com/extensions/auth0-ldap-conector-health-monitor/develop/auth0-ldap-conector-health-monitor-2.2.0.js
  
## 📷 Screenshots
 
  
## 🔗 References
  
[IUM-3387](https://auth0team.atlassian.net/browse/IUM-3387)
  
## 🎯 Testing
  
Versions are verified with [canirequire](https://auth0-extensions.github.io/canirequire) to work with both node12 (current runtime) and node22. I've also tested these pinned versions manually with node12 and node22.

### Node 12 with pinned deps
<img width="953" alt="image" src="https://github.com/user-attachments/assets/90b5ab6d-11d7-42ab-a2e0-82d769e0da42" />

### Node 22 with pinned deps
<img width="949" alt="image" src="https://github.com/user-attachments/assets/574e9913-916c-4fab-b959-317f2f1d85c6" />


✅ This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
    
✅ This can be deployed any time
 
  
## 🎡 Rollout
  
In order to verify that the deployment was successful we will …
  
## 🔥 Rollback
    
We will rollback if …
  
### 📄 Procedure
  
Downgrade to previous version of (`ldap-connector-health-monitor@2.1.2`) in auth0-extensions. This involves changing the `extensions.json` file and then getting [#dx-eco-extensibility-dev](https://okta.enterprise.slack.com/archives/C01TA7U9X3M) to deploy it.
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
